### PR TITLE
Dependencies update and Boggle docs

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,13 +3,13 @@
   "isRoot": true,
   "tools": {
     "csharpier": {
-      "version": "0.30.6",
+      "version": "1.0.2",
       "commands": [
         "dotnet-csharpier"
       ]
     },
     "docfx": {
-      "version": "2.78.2",
+      "version": "2.78.3",
       "commands": [
         "docfx"
       ]
@@ -21,7 +21,7 @@
       ]
     },
     "dotnet-reportgenerator-globaltool": {
-      "version": "5.3.11",
+      "version": "5.4.8",
       "commands": [
         "reportgenerator"
       ]

--- a/.github/CHANGELOG/v3.6.1.md
+++ b/.github/CHANGELOG/v3.6.1.md
@@ -1,0 +1,45 @@
+# Docs fix, dependencies update
+
+## TL; DR 🎯
+
+Bump dependencies to the latest versions, fix documentation information for Boggle example project.
+
+## NEW ✨
+
+- None
+
+## IMPROVED 📈
+
+- Bumped dependencies to:
+  - MSTest.TestAdapter > v3.9.3
+  - MSTest.TestFramework > v3.9.3
+  - Microsoft.NET.Test.Sdk > v17.14.1
+  - csharpier > v1.0.2
+  - docfx > v2.78.3
+  - reportgenerator > v5.4.8
+
+## FIXED 🐛
+
+- Updated [Eliott](https://github.com/aust-1)'s Boggle example project documentation with its name change and links.
+
+## DOCS 📜
+
+- [x] ✅ Docs added
+- [ ] 🚧 Writing docs
+- [ ] ❌ No docs added
+- [ ] ⏩ No docs needed
+
+## TESTS 🔍
+
+- [x] ✅ Features totally covered
+- [ ] 🚧 Features tests incomplete
+- [ ] ❌ No tests added
+- [ ] ⏩ No tests needed
+
+## FEEDBACK 📃
+
+We are always open for feedback and discussions. If you are using our library and want to share your use case, or if you have any suggestions for improvement, please feel free to [open an issue](https://github.com/MorganKryze/ConsoleAppVisuals/issues) or [open a discussion](https://github.com/MorganKryze/ConsoleAppVisuals/discussions) on our GitHub repository. Your input helps us understand possible use cases and make necessary improvements.
+
+---
+
+**Full changelog**: <https://github.com/MorganKryze/ConsoleAppVisuals/compare/v3.6.0...v3.6.1>

--- a/docs/4-examples/ext-boggle.md
+++ b/docs/4-examples/ext-boggle.md
@@ -1,9 +1,9 @@
 ---
 title: Boggle, a word game
-author: Eliott Roussille (austin)
+author: Eliott A. Roussille
 description: Boggle is a word game where players try to find as many words as possible from a grid of letters.
 keywords: c#, documentation, wordgame, boggle
-ms.author: Eliott Roussille (austin)
+ms.author: Eliott A. Roussille
 ms.date: 20/04/2025
 ms.topic: tutorial
 ms.service: ConsoleAppVisuals
@@ -13,7 +13,7 @@ ms.service: ConsoleAppVisuals
 
 |                  Author                  | Size  | Library version |                  Source files                   |
 | :--------------------------------------: | :---: | :-------------: | :---------------------------------------------: |
-| [austin](https://github.com/Captainbleu) |  big  |     v3.5.4      | [Boggle](https://github.com/Captainbleu/Boggle) |
+| [Eliott A. Roussille](https://github.com/aust-1) |  big  |     v3.5.4      | [Boggle](https://github.com/aust-1/Boggle) |
 
 ## Introduction
 
@@ -36,10 +36,10 @@ The project covers the following features:
 To clone the project, run the following command:
 
 ```bash
-git clone https://github.com/Captainbleu/Boggle.git
+git clone https://github.com/aust-1/Boggle.git
 ```
 
-Or alternatively, download the project as a zip file from the [repository](https://github.com/Captainbleu/Boggle).
+Or alternatively, download the project as a zip file from the [repository](https://github.com/aust-1/Boggle).
 
 ### Setup
 

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.8.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.8.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.9.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.9.3" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Description

Bump dependencies to the latest versions, fix documentation information for Boggle example project.

## NEW ✨

- None

## IMPROVED 📈

- Bumped dependencies to:
  - MSTest.TestAdapter > v3.9.3
  - MSTest.TestFramework > v3.9.3
  - Microsoft.NET.Test.Sdk > v17.14.1
  - csharpier > v1.0.2
  - docfx > v2.78.3
  - reportgenerator > v5.4.8

## FIXED 🐛

- Updated [Eliott](https://github.com/aust-1)'s Boggle example project documentation with its name change and links.

## DOCS 📜

- [x] ✅ Docs added
- [ ] 🚧 Writing docs
- [ ] ❌ No docs added
- [ ] ⏩ No docs needed

## TESTS 🔍

- [x] ✅ Features totally covered
- [ ] 🚧 Features tests incomplete
- [ ] ❌ No tests added
- [ ] ⏩ No tests needed
